### PR TITLE
print() is a function in Python 3

### DIFF
--- a/mass_archive.py
+++ b/mass_archive.py
@@ -1,68 +1,74 @@
+from __future__ import print_function
+
 import sys
 import requests
 import archiveis
 import json
 
-target     = sys.argv[1]
-input      = str(target)
+URL = "https://api.perma.cc/v1/archives/?api_key=YOUR_PERMA_API_KEY_HERE"
 
-print "[*] Archiving %s..." % input
+target = str(sys.argv[1])
+
+print("[*] Archiving %s..." % target)
+
 
 #
 # function for pushing to The Internet Archive/Wayback Machine
 #
-def internet_archive(input):
-    
-    print "[*] Pushing to the Wayback Machine..."
-    
-    save_url = "https://web.archive.org/save/%s" % input
-    
+def internet_archive(target):
+
+    print("[*] Pushing to the Wayback Machine...")
+
+    save_url = "https://web.archive.org/save/%s" % target
+
     # send off request to wayback machine
     response = requests.get(save_url)
-    
+
     if response.status_code == 200:
-        
+
         # grab the part of the URL dealing with the archive page
-        result               = response.headers['Content-Location']
-        
-        # build archive URL 
+        result = response.headers['Content-Location']
+
+        # build archive URL
         internet_archive_url = "https://web.archive.org%s" % result
-        
+
         return internet_archive_url
     else:
-        print "[!] Connection error"
+        print("[!] Connection error")
+
 
 #
 # function for pushing to Perma.cc
-#   
-def perma(input):
-    
-    print "[*] Pushing to Perma.cc..."
-    
+#
+def perma(target):
+
+    print("[*] Pushing to Perma.cc...")
+
     perma_json = {}
-    perma_json['url'] = '%s' % input
-    
+    perma_json['url'] = '%s' % target
+
     # remember to put your Perma.cc API key in here
-    response = requests.post("https://api.perma.cc/v1/archives/?api_key=YOUR_PERMA_API_KEY_HERE", data=perma_json)
+    response = requests.post(URL, data=perma_json)
     if response.status_code == 201:
-         
+
         result = json.loads(response.content)
         page_id = result['guid']
         perma_url = "https://perma.cc/%s" % page_id
 
         return perma_url
     else:
-        print "[*] Connection error"
-    
+        print("[*] Connection error")
+
+
 # push to The Internet Archive
-internet_archive_result = internet_archive(input)
-print internet_archive_result
+internet_archive_result = internet_archive(target)
+print(internet_archive_result)
 
 # push to archive.is
-print "[*] Pushing to archive.is..."
-archiveis_result = archiveis.capture(input)
-print archiveis_result
+print("[*] Pushing to archive.is...")
+archiveis_result = archiveis.capture(target)
+print(archiveis_result)
 
 # push to perma.cc
-perma_result = perma(input)
-print perma_result
+perma_result = perma(target)
+print(perma_result)

--- a/mass_archive.py
+++ b/mass_archive.py
@@ -3,9 +3,8 @@ from __future__ import print_function
 import sys
 import requests
 import archiveis
-import json
 
-URL = "https://api.perma.cc/v1/archives/?api_key=YOUR_PERMA_API_KEY_HERE"
+PERMA_AIP_KEY = ""  # <-- remember to put your Perma.cc API key in here
 
 target = str(sys.argv[1])
 
@@ -42,17 +41,14 @@ def internet_archive(target):
 #
 def perma(target):
 
+    assert PERMA_AIP_KEY, "PERMA_AIP_KEY is not set."
     print("[*] Pushing to Perma.cc...")
 
-    perma_json = {}
-    perma_json['url'] = '%s' % target
-
-    # remember to put your Perma.cc API key in here
-    response = requests.post(URL, data=perma_json)
+    response = requests.post("https://api.perma.cc/v1/archives/?api_key=" +
+                             PERMA_AIP_KEY, data={'url': target})
     if response.status_code == 201:
 
-        result = json.loads(response.content)
-        page_id = result['guid']
+        page_id = response.json()['guid']
         perma_url = "https://perma.cc/%s" % page_id
 
         return perma_url
@@ -70,5 +66,5 @@ archiveis_result = archiveis.capture(target)
 print(archiveis_result)
 
 # push to perma.cc
-perma_result = perma(target)
+perma_result = perma(target) if PERMA_AIP_KEY else "Skipping Perma: No API key"
 print(perma_result)


### PR DESCRIPTION
Also:
* replace __input__ with __target__ because __input()__ is a builtin function in both Python 2 and Python 3
* move __PERMA_API_KEY__ to the top of the file because users can modify it
* Skip perma.cc processing if the API key is not present
* Use __requests__ builtin __.json()__ method
* remove trailing whitespace
