### PR TITLE
Enforce HTTPS URL for archive.is

### DIFF
--- a/mass_archive.py
+++ b/mass_archive.py
@@ -60,7 +60,7 @@ print internet_archive_result
 
 # push to archive.is
 print "[*] Pushing to archive.is..."
-archiveis_result = archiveis.capture(input)
+archiveis_result = archiveis.capture(input).replace("http://", "https://")
 print archiveis_result
 
 # push to perma.cc


### PR DESCRIPTION
archive.is returns a `http://` URL by default but seems to support `https://`.

There are reasons for and against handling it this way, but I thought we might as well put it to a (BDFL) vote. :)