### PR TITLE
Fix archive.is "Connection Error" [Requests] Exception

### DIFF
--- a/mass_archive.py
+++ b/mass_archive.py
@@ -60,8 +60,12 @@ print internet_archive_result
 
 # push to archive.is
 print "[*] Pushing to archive.is..."
-archiveis_result = archiveis.capture(input).replace("http://", "https://")
-print archiveis_result
+try:
+    archiveis_result = archiveis.capture(input).replace("http://", "https://")
+    print archiveis_result
+
+except requests.exceptions.ConnectionError:
+    print "[*] Connection error"
 
 # push to perma.cc
 perma_result = perma(input)


### PR DESCRIPTION
The `requests.exceptions.ConnectionError` is thrown as shown in the Trace below: 

`$ python mass_archive.py https://cmlh.id.au`
`[*] Archiving https://cmlh.id.au...`
`[*] Pushing to the Wayback Machine...`
`[!] Connection error`
`[*] Pushing to archive.is...`
`Traceback (most recent call last):`
`  File "mass_archive.py", line 64, in <module>
    archiveis_result = archiveis.capture(input).replace("http://", "https://")`
`  File "C:\Users\cmlh\venv\lib\site-packages\archiveis\api.py", line 35, in capture
    headers=headers`
`  File "C:\Users\cmlh\venv\lib\site-packages\requests\api.py", line 72, in get
    return request('get', url, params=params, **kwargs)`
`  File "C:\Users\cmlh\venv\lib\site-packages\requests\api.py", line 58, in request
    return session.request(method=method, url=url, **kwargs)`
`  File "C:\Users\cmlh\venv\lib\site-packages\requests\sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)`
`  File "C:\Users\cmlh\venv\lib\site-packages\requests\sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)`
`  File "C:\Users\cmlh\venv\lib\site-packages\requests\adapters.py", line 508, in send
    raise ConnectionError(e, request=request)`
`requests.exceptions.ConnectionError: HTTPConnectionPool(host='archive.is', port=80): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x056C8F50>: Failed to establish a new connection: [Errno 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond',))`

The output after catching the `requests.exceptions.ConnectionError` is below:
`$ python mass_archive.py https://cmlh.id.au`
`[*] Archiving https://cmlh.id.au...`
`[*] Pushing to the Wayback Machine...`
`[!] Connection error`
`None`
`[*] Pushing to archive.is...`
`[*] Connection error`
`[*] Pushing to Perma.cc...`
`[*] Connection error`
`None`

Signed-off-by: Christian Heinrich <christian.heinrich@cmlh.id.au>